### PR TITLE
add @JvmOverloads to HikakuConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,7 @@ public class SpecificationTest {
     SpringConverter springConverter = new SpringConverter(springContext);
 
     HikakuConfig hikakuConfig = new HikakuConfig(
-        new HashSet<>(Arrays.asList(SpringConverter.IGNORE_ERROR_ENDPOINT)),
-        false,
-        false,
-        new CommandLineReporter()
+        new HashSet<>(Arrays.asList(SpringConverter.IGNORE_ERROR_ENDPOINT))
     );
     
     new Hikaku(

--- a/core/src/main/kotlin/de/codecentric/hikaku/HikakuConfig.kt
+++ b/core/src/main/kotlin/de/codecentric/hikaku/HikakuConfig.kt
@@ -3,8 +3,8 @@ package de.codecentric.hikaku
 import de.codecentric.hikaku.endpoints.Endpoint
 import de.codecentric.hikaku.endpoints.HttpMethod.HEAD
 import de.codecentric.hikaku.endpoints.HttpMethod.OPTIONS
-import de.codecentric.hikaku.reporter.MatchResult
 import de.codecentric.hikaku.reporter.CommandLineReporter
+import de.codecentric.hikaku.reporter.MatchResult
 import de.codecentric.hikaku.reporter.Reporter
 
 /**
@@ -14,7 +14,8 @@ import de.codecentric.hikaku.reporter.Reporter
  * @param ignoreHttpMethodOptions All checks for an [Endpoint] providing http method [OPTIONS] will be skipped if set to `true`.
  * @param reporter The [MatchResult] will be passed to one or many [Reporter] before the test either fails or succeeds. Default is a [CommandLineReporter] that prints the results to stdout.
  */
-data class HikakuConfig(
+data class HikakuConfig
+@JvmOverloads constructor(
         val ignorePaths: Set<String> = emptySet(),
         val ignoreHttpMethodHead: Boolean = false,
         val ignoreHttpMethodOptions: Boolean = false,


### PR DESCRIPTION
add @JvmOverloads to make the HikakuConfig behave the same way in java and kotlin