### PR TITLE
Add deprecation check feature

### DIFF
--- a/core/src/main/kotlin/de/codecentric/hikaku/Hikaku.kt
+++ b/core/src/main/kotlin/de/codecentric/hikaku/Hikaku.kt
@@ -85,7 +85,7 @@ class Hikaku(
                     Feature.MatrixParameters -> matches && it.matrixParameters == otherEndpoint.matrixParameters
                     Feature.Produces -> matches && it.produces == otherEndpoint.produces
                     Feature.Consumes -> matches && it.consumes == otherEndpoint.consumes
-                    Feature.Deprecated -> matches && it.deprecated == otherEndpoint.deprecated
+                    Feature.Deprecation -> matches && it.deprecated == otherEndpoint.deprecated
                 }
             }
 

--- a/core/src/main/kotlin/de/codecentric/hikaku/Hikaku.kt
+++ b/core/src/main/kotlin/de/codecentric/hikaku/Hikaku.kt
@@ -85,6 +85,7 @@ class Hikaku(
                     Feature.MatrixParameters -> matches && it.matrixParameters == otherEndpoint.matrixParameters
                     Feature.Produces -> matches && it.produces == otherEndpoint.produces
                     Feature.Consumes -> matches && it.consumes == otherEndpoint.consumes
+                    Feature.Deprecated -> matches && it.deprecated == otherEndpoint.deprecated
                 }
             }
 

--- a/core/src/main/kotlin/de/codecentric/hikaku/SupportedFeatures.kt
+++ b/core/src/main/kotlin/de/codecentric/hikaku/SupportedFeatures.kt
@@ -23,6 +23,8 @@ class SupportedFeatures(
         /** Checks supported media type of requests. */
         Consumes,
         /** Checks the equality of matrix parameters. */
-        MatrixParameters
+        MatrixParameters,
+        /** Checks the equality of deprecation. */
+        Deprecated
     }
 }

--- a/core/src/main/kotlin/de/codecentric/hikaku/SupportedFeatures.kt
+++ b/core/src/main/kotlin/de/codecentric/hikaku/SupportedFeatures.kt
@@ -25,6 +25,6 @@ class SupportedFeatures(
         /** Checks the equality of matrix parameters. */
         MatrixParameters,
         /** Checks the equality of deprecation. */
-        Deprecated
+        Deprecation
     }
 }

--- a/core/src/main/kotlin/de/codecentric/hikaku/endpoints/Endpoint.kt
+++ b/core/src/main/kotlin/de/codecentric/hikaku/endpoints/Endpoint.kt
@@ -17,5 +17,6 @@ data class Endpoint(
         val headerParameters: Set<HeaderParameter> = emptySet(),
         val matrixParameters: Set<MatrixParameter> = emptySet(),
         val produces: Set<String> = emptySet(),
-        val consumes: Set<String> = emptySet()
+        val consumes: Set<String> = emptySet(),
+        val deprecated: Boolean = false
 )

--- a/core/src/main/kotlin/de/codecentric/hikaku/reporters/CommandLineReporter.kt
+++ b/core/src/main/kotlin/de/codecentric/hikaku/reporters/CommandLineReporter.kt
@@ -54,7 +54,7 @@ class CommandLineReporter : Reporter {
                 Feature.MatrixParameters -> listMatrixParameter(endpoint.matrixParameters)
                 Feature.Consumes -> listRequestMediaTypes(endpoint.consumes)
                 Feature.Produces -> listResponseMediaTypes(endpoint.produces)
-                Feature.Deprecation -> if (endpoint.deprecated) "  Deprecation" else ""
+                Feature.Deprecation -> if (endpoint.deprecated) "  Deprecated" else ""
             }
         }
 

--- a/core/src/main/kotlin/de/codecentric/hikaku/reporters/CommandLineReporter.kt
+++ b/core/src/main/kotlin/de/codecentric/hikaku/reporters/CommandLineReporter.kt
@@ -54,6 +54,7 @@ class CommandLineReporter : Reporter {
                 Feature.MatrixParameters -> listMatrixParameter(endpoint.matrixParameters)
                 Feature.Consumes -> listRequestMediaTypes(endpoint.consumes)
                 Feature.Produces -> listResponseMediaTypes(endpoint.produces)
+                Feature.Deprecated -> if (endpoint.deprecated) "  Deprecated" else ""
             }
         }
 

--- a/core/src/main/kotlin/de/codecentric/hikaku/reporters/CommandLineReporter.kt
+++ b/core/src/main/kotlin/de/codecentric/hikaku/reporters/CommandLineReporter.kt
@@ -54,7 +54,7 @@ class CommandLineReporter : Reporter {
                 Feature.MatrixParameters -> listMatrixParameter(endpoint.matrixParameters)
                 Feature.Consumes -> listRequestMediaTypes(endpoint.consumes)
                 Feature.Produces -> listResponseMediaTypes(endpoint.produces)
-                Feature.Deprecated -> if (endpoint.deprecated) "  Deprecated" else ""
+                Feature.Deprecation -> if (endpoint.deprecated) "  Deprecation" else ""
             }
         }
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -12,3 +12,4 @@ There might be various ways to declare or use a feature, so check each converter
 | MatrixParameters | Name of a matrix parameter and whether the parameter is required or not. _Example:_ `/todos;param=value` | ❌ | ✅ _(2.1.0)_ | ✅ _(2.1.0)_ | ❌ | ✅ _(2.1.0)_ | ❌ |
 | Produces | Checks the supported media types of the response. | ✅ _(1.1.0)_ | ✅ _(1.1.0)_ | ✅ _(1.1.0)_ | ✅ _(2.0.0)_ | ✅ _(2.1.0)_ | ✅ _(2.3.0)_ |
 | Consumes | Checks the supported media types of the request. | ✅ _(1.1.0)_ | ✅ _(1.1.0)_ | ✅ _(1.1.0)_ | ✅ _(2.0.0)_ | ✅ _(2.1.0)_ | ✅ _(2.3.0)_ |
+| Deprecation | Checks deprecated endpoints are properly marked. | ✅ _(2.3.0)_ | ✅ _(2.3.0)_ | ❌ | ✅ _(2.3.0)_ | ✅ _(2.3.0)_ | ✅ _(2.3.0)_ |

--- a/jax-rs/src/main/kotlin/de/codecentric/hikaku/converters/jaxrs/JaxRsConverter.kt
+++ b/jax-rs/src/main/kotlin/de/codecentric/hikaku/converters/jaxrs/JaxRsConverter.kt
@@ -61,8 +61,7 @@ class JaxRsConverter(private val packageName: String) : AbstractEndpointConverte
             matrixParameters = extractMatrixParameters(method),
             produces = extractProduces(resource, method),
             consumes = extractConsumes(resource, method),
-            deprecated = method.isAnnotationPresent(Deprecated::class.java)
-                || method.declaringClass.isAnnotationPresent(Deprecated::class.java)
+            deprecated = isEndpointDeprecated(method)
     )
 
     private fun extractPath(resource: Class<*>, method: Method): String {
@@ -176,4 +175,8 @@ class JaxRsConverter(private val packageName: String) : AbstractEndpointConverte
                 .map { MatrixParameter(it) }
                 .toSet()
     }
+
+    private fun isEndpointDeprecated(method: Method) =
+            method.isAnnotationPresent(Deprecated::class.java)
+                    || method.declaringClass.isAnnotationPresent(Deprecated::class.java)
 }

--- a/jax-rs/src/main/kotlin/de/codecentric/hikaku/converters/jaxrs/JaxRsConverter.kt
+++ b/jax-rs/src/main/kotlin/de/codecentric/hikaku/converters/jaxrs/JaxRsConverter.kt
@@ -19,7 +19,7 @@ class JaxRsConverter(private val packageName: String) : AbstractEndpointConverte
             Feature.MatrixParameters,
             Feature.Consumes,
             Feature.Produces,
-            Feature.Deprecated
+            Feature.Deprecation
     )
 
     override fun convert(): Set<Endpoint> {

--- a/jax-rs/src/main/kotlin/de/codecentric/hikaku/converters/jaxrs/JaxRsConverter.kt
+++ b/jax-rs/src/main/kotlin/de/codecentric/hikaku/converters/jaxrs/JaxRsConverter.kt
@@ -18,7 +18,8 @@ class JaxRsConverter(private val packageName: String) : AbstractEndpointConverte
             Feature.HeaderParameters,
             Feature.MatrixParameters,
             Feature.Consumes,
-            Feature.Produces
+            Feature.Produces,
+            Feature.Deprecated
     )
 
     override fun convert(): Set<Endpoint> {
@@ -59,7 +60,9 @@ class JaxRsConverter(private val packageName: String) : AbstractEndpointConverte
             headerParameters = extractHeaderParameters(method),
             matrixParameters = extractMatrixParameters(method),
             produces = extractProduces(resource, method),
-            consumes = extractConsumes(resource, method)
+            consumes = extractConsumes(resource, method),
+            deprecated = method.isAnnotationPresent(Deprecated::class.java)
+                || method.declaringClass.isAnnotationPresent(Deprecated::class.java)
     )
 
     private fun extractPath(resource: Class<*>, method: Method): String {

--- a/jax-rs/src/test/kotlin/de/codecentric/hikaku/converters/jaxrs/JaxRsConverterDeprecationTest.kt
+++ b/jax-rs/src/test/kotlin/de/codecentric/hikaku/converters/jaxrs/JaxRsConverterDeprecationTest.kt
@@ -1,0 +1,63 @@
+package de.codecentric.hikaku.converters.jaxrs
+
+import de.codecentric.hikaku.endpoints.Endpoint
+import de.codecentric.hikaku.endpoints.HttpMethod.GET
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class JaxRsConverterDeprecationTest {
+
+    @Test
+    fun `no deprecation`() {
+        // given
+        val specification = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        deprecated =  false
+                )
+        )
+
+        //when
+        val result = JaxRsConverter("test.jaxrs.deprecation.none").conversionResult
+
+        //then
+        assertThat(result).containsExactlyInAnyOrderElementsOf(specification)
+    }
+
+    @Test
+    fun `deprecated class`() {
+        // given
+        val specification = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        deprecated =  true
+                )
+        )
+
+        //when
+        val result = JaxRsConverter("test.jaxrs.deprecation.onclass").conversionResult
+
+        //then
+        assertThat(result).containsExactlyInAnyOrderElementsOf(specification)
+    }
+
+    @Test
+    fun `deprecated function`() {
+        // given
+        val specification = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        deprecated = true
+                )
+        )
+
+        //when
+        val result = JaxRsConverter("test.jaxrs.deprecation.onfunction").conversionResult
+
+        //then
+        assertThat(result).containsExactlyInAnyOrderElementsOf(specification)
+    }
+}

--- a/jax-rs/src/test/kotlin/test/jaxrs/deprecation/none/NoDeprecation.kt
+++ b/jax-rs/src/test/kotlin/test/jaxrs/deprecation/none/NoDeprecation.kt
@@ -1,0 +1,11 @@
+package test.jaxrs.deprecation.none
+
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+
+@Path("/todos")
+class NoDeprecation {
+
+    @GET
+    fun todo() { }
+}

--- a/jax-rs/src/test/kotlin/test/jaxrs/deprecation/onclass/DeprecationOnClass.kt
+++ b/jax-rs/src/test/kotlin/test/jaxrs/deprecation/onclass/DeprecationOnClass.kt
@@ -1,0 +1,12 @@
+package test.jaxrs.deprecation.onclass
+
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+
+@Path("/todos")
+@Deprecated("Test")
+class DeprecationOnClass {
+
+    @GET
+    fun todo() { }
+}

--- a/jax-rs/src/test/kotlin/test/jaxrs/deprecation/onfunction/DeprecationOnFunction.kt
+++ b/jax-rs/src/test/kotlin/test/jaxrs/deprecation/onfunction/DeprecationOnFunction.kt
@@ -1,0 +1,12 @@
+package test.jaxrs.deprecation.onfunction
+
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+
+@Path("/todos")
+class DeprecationOnFunction {
+
+    @GET
+    @Deprecated("Test")
+    fun todo() { }
+}

--- a/micronaut/src/main/kotlin/de/codecentric/hikaku/converters/micronaut/MicronautConverter.kt
+++ b/micronaut/src/main/kotlin/de/codecentric/hikaku/converters/micronaut/MicronautConverter.kt
@@ -61,7 +61,9 @@ class MicronautConverter(private val packageName: String) : AbstractEndpointConv
                 pathParameters = extractPathParameters(path, method),
                 headerParameters = extractHeaderParameters(method),
                 consumes = extractConsumes(resource, method),
-                produces = extractProduces(resource, method)
+                produces = extractProduces(resource, method),
+                deprecated = method.isAnnotationPresent(Deprecated::class.java)
+                    || method.declaringClass.isAnnotationPresent(Deprecated::class.java)
         )
     }
 

--- a/micronaut/src/main/kotlin/de/codecentric/hikaku/converters/micronaut/MicronautConverter.kt
+++ b/micronaut/src/main/kotlin/de/codecentric/hikaku/converters/micronaut/MicronautConverter.kt
@@ -18,7 +18,8 @@ class MicronautConverter(private val packageName: String) : AbstractEndpointConv
         Feature.PathParameters,
         Feature.HeaderParameters,
         Feature.Produces,
-        Feature.Consumes
+        Feature.Consumes,
+        Feature.Deprecation
     )
 
     override fun convert(): Set<Endpoint> {
@@ -62,8 +63,7 @@ class MicronautConverter(private val packageName: String) : AbstractEndpointConv
                 headerParameters = extractHeaderParameters(method),
                 consumes = extractConsumes(resource, method),
                 produces = extractProduces(resource, method),
-                deprecated = method.isAnnotationPresent(Deprecated::class.java)
-                    || method.declaringClass.isAnnotationPresent(Deprecated::class.java)
+                deprecated = isEndpointDeprecated(method)
         )
     }
 
@@ -250,4 +250,8 @@ class MicronautConverter(private val packageName: String) : AbstractEndpointConv
                 .map { HeaderParameter(it.value, it.defaultValue.isBlank()) }
                 .toSet()
     }
+
+    private fun isEndpointDeprecated(method: Method) =
+            method.isAnnotationPresent(Deprecated::class.java)
+                    || method.declaringClass.isAnnotationPresent(Deprecated::class.java)
 }

--- a/micronaut/src/test/kotlin/de/codecentric/hikaku/converters/micronaut/MicronautConverterDeprecationTest.kt
+++ b/micronaut/src/test/kotlin/de/codecentric/hikaku/converters/micronaut/MicronautConverterDeprecationTest.kt
@@ -1,0 +1,63 @@
+package de.codecentric.hikaku.converters.micronaut
+
+import de.codecentric.hikaku.endpoints.Endpoint
+import de.codecentric.hikaku.endpoints.HttpMethod.GET
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MicronautConverterDeprecationTest {
+
+    @Test
+    fun `no deprecation`() {
+        // given
+        val specification = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        deprecated =  false
+                )
+        )
+
+        //when
+        val result = MicronautConverter("test.micronaut.deprecation.none").conversionResult
+
+        //then
+        assertThat(result).containsExactlyInAnyOrderElementsOf(specification)
+    }
+
+    @Test
+    fun `deprecated class`() {
+        // given
+        val specification = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        deprecated =  true
+                )
+        )
+
+        //when
+        val result = MicronautConverter("test.micronaut.deprecation.onclass").conversionResult
+
+        //then
+        assertThat(result).containsExactlyInAnyOrderElementsOf(specification)
+    }
+
+    @Test
+    fun `deprecated function`() {
+        // given
+        val specification = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        deprecated = true
+                )
+        )
+
+        //when
+        val result = MicronautConverter("test.micronaut.deprecation.onfunction").conversionResult
+
+        //then
+        assertThat(result).containsExactlyInAnyOrderElementsOf(specification)
+    }
+}

--- a/micronaut/src/test/kotlin/test/micronaut/deprecation/none/NoDeprecation.kt
+++ b/micronaut/src/test/kotlin/test/micronaut/deprecation/none/NoDeprecation.kt
@@ -1,0 +1,11 @@
+package test.micronaut.deprecation.none
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Controller("/todos", produces = ["text/plain", "application/xml"])
+class NoDeprecation {
+
+    @Get
+    fun todo() { }
+}

--- a/micronaut/src/test/kotlin/test/micronaut/deprecation/none/NoDeprecation.kt
+++ b/micronaut/src/test/kotlin/test/micronaut/deprecation/none/NoDeprecation.kt
@@ -3,7 +3,7 @@ package test.micronaut.deprecation.none
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 
-@Controller("/todos", produces = ["text/plain", "application/xml"])
+@Controller("/todos")
 class NoDeprecation {
 
     @Get

--- a/micronaut/src/test/kotlin/test/micronaut/deprecation/onclass/DeprecationOnClass.kt
+++ b/micronaut/src/test/kotlin/test/micronaut/deprecation/onclass/DeprecationOnClass.kt
@@ -3,7 +3,7 @@ package test.micronaut.deprecation.onclass
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 
-@Controller("/todos", produces = ["text/plain", "application/xml"])
+@Controller("/todos")
 @Deprecated("Test")
 class DeprecationOnClass {
 

--- a/micronaut/src/test/kotlin/test/micronaut/deprecation/onclass/DeprecationOnClass.kt
+++ b/micronaut/src/test/kotlin/test/micronaut/deprecation/onclass/DeprecationOnClass.kt
@@ -1,0 +1,12 @@
+package test.micronaut.deprecation.onclass
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Controller("/todos", produces = ["text/plain", "application/xml"])
+@Deprecated("Test")
+class DeprecationOnClass {
+
+    @Get
+    fun todo() { }
+}

--- a/micronaut/src/test/kotlin/test/micronaut/deprecation/onfunction/DeprecationOnFunction.kt
+++ b/micronaut/src/test/kotlin/test/micronaut/deprecation/onfunction/DeprecationOnFunction.kt
@@ -3,7 +3,7 @@ package test.micronaut.deprecation.onfunction
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 
-@Controller("/todos", produces = ["text/plain", "application/xml"])
+@Controller("/todos")
 class DeprecationOnFunction {
 
     @Get

--- a/micronaut/src/test/kotlin/test/micronaut/deprecation/onfunction/DeprecationOnFunction.kt
+++ b/micronaut/src/test/kotlin/test/micronaut/deprecation/onfunction/DeprecationOnFunction.kt
@@ -1,0 +1,12 @@
+package test.micronaut.deprecation.onfunction
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Controller("/todos", produces = ["text/plain", "application/xml"])
+class DeprecationOnFunction {
+
+    @Get
+    @Deprecated("Test")
+    fun todo() { }
+}

--- a/openapi/src/main/kotlin/de/codecentric/hikaku/converters/openapi/OpenApiConverter.kt
+++ b/openapi/src/main/kotlin/de/codecentric/hikaku/converters/openapi/OpenApiConverter.kt
@@ -35,7 +35,8 @@ class OpenApiConverter private constructor(private val specificationContent: Str
             Feature.PathParameters,
             Feature.HeaderParameters,
             Feature.Produces,
-            Feature.Consumes
+            Feature.Consumes,
+            Feature.Deprecated
     )
 
     override fun convert(): Set<Endpoint> {
@@ -66,7 +67,8 @@ class OpenApiConverter private constructor(private val specificationContent: Str
                         pathParameters = extractPathParameters(operation),
                         headerParameters = extractHeaderParameters(operation),
                         consumes = extractConsumesMediaTypes(operation),
-                        produces = extractProduceMediaTypes(operation)
+                        produces = extractProduceMediaTypes(operation),
+                        deprecated = operation?.deprecated ?: false
                 )
             }
         }

--- a/openapi/src/main/kotlin/de/codecentric/hikaku/converters/openapi/OpenApiConverter.kt
+++ b/openapi/src/main/kotlin/de/codecentric/hikaku/converters/openapi/OpenApiConverter.kt
@@ -36,7 +36,7 @@ class OpenApiConverter private constructor(private val specificationContent: Str
             Feature.HeaderParameters,
             Feature.Produces,
             Feature.Consumes,
-            Feature.Deprecated
+            Feature.Deprecation
     )
 
     override fun convert(): Set<Endpoint> {

--- a/openapi/src/test/kotlin/de/codecentric/hikaku/converters/openapi/OpenApiConverterDeprecationTest.kt
+++ b/openapi/src/test/kotlin/de/codecentric/hikaku/converters/openapi/OpenApiConverterDeprecationTest.kt
@@ -29,27 +29,7 @@ class OpenApiConverterDeprecationTest {
     }
 
     @Test
-    fun `deprecated class`() {
-        //given
-        val file = Paths.get(this::class.java.classLoader.getResource("deprecation/deprecation_operation.yaml").toURI())
-        val implementation = setOf(
-                Endpoint(
-                        path = "/todos",
-                        httpMethod = GET,
-                        produces = setOf("application/json"),
-                        deprecated = true
-                )
-        )
-
-        //when
-        val specification = OpenApiConverter(file)
-
-        //then
-        assertThat(specification.conversionResult).containsExactlyInAnyOrderElementsOf(implementation)
-    }
-
-    @Test
-    fun `deprecated function`() {
+    fun `deprecated operation`() {
         //given
         val file = Paths.get(this::class.java.classLoader.getResource("deprecation/deprecation_operation.yaml").toURI())
         val implementation = setOf(

--- a/openapi/src/test/kotlin/de/codecentric/hikaku/converters/openapi/OpenApiConverterDeprecationTest.kt
+++ b/openapi/src/test/kotlin/de/codecentric/hikaku/converters/openapi/OpenApiConverterDeprecationTest.kt
@@ -1,0 +1,70 @@
+package de.codecentric.hikaku.converters.openapi
+
+import de.codecentric.hikaku.endpoints.Endpoint
+import de.codecentric.hikaku.endpoints.HttpMethod.GET
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.file.Paths
+
+class OpenApiConverterDeprecationTest {
+
+    @Test
+    fun `no deprecation`() {
+        //given
+        val file = Paths.get(this::class.java.classLoader.getResource("deprecation/deprecation_none.yaml").toURI())
+        val implementation = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        produces = setOf("application/json"),
+                        deprecated = false
+                )
+        )
+
+        //when
+        val specification = OpenApiConverter(file)
+
+        //then
+        assertThat(specification.conversionResult).containsExactlyInAnyOrderElementsOf(implementation)
+    }
+
+    @Test
+    fun `deprecated class`() {
+        //given
+        val file = Paths.get(this::class.java.classLoader.getResource("deprecation/deprecation_operation.yaml").toURI())
+        val implementation = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        produces = setOf("application/json"),
+                        deprecated = true
+                )
+        )
+
+        //when
+        val specification = OpenApiConverter(file)
+
+        //then
+        assertThat(specification.conversionResult).containsExactlyInAnyOrderElementsOf(implementation)
+    }
+
+    @Test
+    fun `deprecated function`() {
+        //given
+        val file = Paths.get(this::class.java.classLoader.getResource("deprecation/deprecation_operation.yaml").toURI())
+        val implementation = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        produces = setOf("application/json"),
+                        deprecated = true
+                )
+        )
+
+        //when
+        val specification = OpenApiConverter(file)
+
+        //then
+        assertThat(specification.conversionResult).containsExactlyInAnyOrderElementsOf(implementation)
+    }
+}

--- a/openapi/src/test/resources/deprecation/deprecation_none.yaml
+++ b/openapi/src/test/resources/deprecation/deprecation_none.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.2
+info:
+  version: 1.0.0
+  title: Todo List
+paths:
+  /todos:
+    get:
+      deprecated: false
+      description: ''
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/openapi/src/test/resources/deprecation/deprecation_operation.yaml
+++ b/openapi/src/test/resources/deprecation/deprecation_operation.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.2
+info:
+  version: 1.0.0
+  title: Todo List
+paths:
+  /todos:
+    get:
+      deprecated: true
+      description: ''
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/raml/src/main/kotlin/de/codecentric/hikaku/converters/raml/RamlConverter.kt
+++ b/raml/src/main/kotlin/de/codecentric/hikaku/converters/raml/RamlConverter.kt
@@ -23,7 +23,7 @@ class RamlConverter(private val ramlSpecification: File) : AbstractEndpointConve
             Feature.HeaderParameters,
             Feature.Produces,
             Feature.Consumes,
-            Feature.Deprecated
+            Feature.Deprecation
     )
 
     override fun convert(): Set<Endpoint> {

--- a/raml/src/main/kotlin/de/codecentric/hikaku/converters/raml/RamlConverter.kt
+++ b/raml/src/main/kotlin/de/codecentric/hikaku/converters/raml/RamlConverter.kt
@@ -70,8 +70,7 @@ class RamlConverter(private val ramlSpecification: File) : AbstractEndpointConve
                             headerParameters = it?.hikakuHeaderParameters().orEmpty(),
                             consumes = it.requestMediaTypes(),
                             produces = it.responseMediaTypes(),
-                            deprecated = it.annotations().any { i -> i.annotation().name() == "deprecated" }
-                                    || resource.annotations().any { i -> i.annotation().name() == "deprecated" }
+                            deprecated = it.isEndpointDeprecated()
                     )
             }
         }

--- a/raml/src/main/kotlin/de/codecentric/hikaku/converters/raml/RamlConverter.kt
+++ b/raml/src/main/kotlin/de/codecentric/hikaku/converters/raml/RamlConverter.kt
@@ -71,6 +71,7 @@ class RamlConverter(private val ramlSpecification: File) : AbstractEndpointConve
                             consumes = it.requestMediaTypes(),
                             produces = it.responseMediaTypes(),
                             deprecated = it.annotations().any { i -> i.annotation().name() == "deprecated" }
+                                    || resource.annotations().any { i -> i.annotation().name() == "deprecated" }
                     )
             }
         }

--- a/raml/src/main/kotlin/de/codecentric/hikaku/converters/raml/RamlConverter.kt
+++ b/raml/src/main/kotlin/de/codecentric/hikaku/converters/raml/RamlConverter.kt
@@ -1,7 +1,7 @@
 package de.codecentric.hikaku.converters.raml
 
 import de.codecentric.hikaku.SupportedFeatures
-import de.codecentric.hikaku.SupportedFeatures.*
+import de.codecentric.hikaku.SupportedFeatures.Feature
 import de.codecentric.hikaku.converters.AbstractEndpointConverter
 import de.codecentric.hikaku.converters.EndpointConverterException
 import de.codecentric.hikaku.converters.raml.extensions.*
@@ -22,7 +22,8 @@ class RamlConverter(private val ramlSpecification: File) : AbstractEndpointConve
             Feature.PathParameters,
             Feature.HeaderParameters,
             Feature.Produces,
-            Feature.Consumes
+            Feature.Consumes,
+            Feature.Deprecated
     )
 
     override fun convert(): Set<Endpoint> {
@@ -68,7 +69,8 @@ class RamlConverter(private val ramlSpecification: File) : AbstractEndpointConve
                             pathParameters = it.resource()?.hikakuPathParameters().orEmpty(),
                             headerParameters = it?.hikakuHeaderParameters().orEmpty(),
                             consumes = it.requestMediaTypes(),
-                            produces = it.responseMediaTypes()
+                            produces = it.responseMediaTypes(),
+                            deprecated = it.annotations().any { i -> i.annotation().name() == "deprecated" }
                     )
             }
         }

--- a/raml/src/main/kotlin/de/codecentric/hikaku/converters/raml/extensions/MethodExtensions.kt
+++ b/raml/src/main/kotlin/de/codecentric/hikaku/converters/raml/extensions/MethodExtensions.kt
@@ -34,5 +34,9 @@ internal fun Method.responseMediaTypes(): Set<String> {
     return this.responses().flatMap {response ->
         response.body().map { it.name() }
     }
-    .toSet()
+            .toSet()
 }
+
+internal fun Method.isEndpointDeprecated() =
+        this.annotations().any { i -> i.annotation().name() == "deprecated" }
+                || checkNotNull(this.resource()).annotations().any { i -> i.annotation().name() == "deprecated" }

--- a/raml/src/test/kotlin/de/codecentric/hikaku/converters/raml/RamlConverterDeprecationTest.kt
+++ b/raml/src/test/kotlin/de/codecentric/hikaku/converters/raml/RamlConverterDeprecationTest.kt
@@ -1,0 +1,73 @@
+package de.codecentric.hikaku.converters.raml
+
+import de.codecentric.hikaku.endpoints.Endpoint
+import de.codecentric.hikaku.endpoints.HttpMethod.GET
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.file.Paths
+
+class RamlConverterDeprecationTest {
+
+    @Test
+    fun `no deprecations`() {
+        //given
+        val file = Paths.get(this::class.java.classLoader.getResource("deprecation/none.raml").toURI())
+
+        val specification = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        produces = setOf("text/plain"),
+                        deprecated = false
+                )
+        )
+
+        //when
+        val implementation = RamlConverter(file).conversionResult
+
+        //then
+        assertThat(implementation).containsExactlyInAnyOrderElementsOf(specification)
+    }
+
+    @Test
+    fun `deprecated resource`() {
+        //given
+        val file = Paths.get(this::class.java.classLoader.getResource("deprecation/on_resource.raml").toURI())
+
+        val specification = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        produces = setOf("text/plain"),
+                        deprecated = true
+                )
+        )
+
+        //when
+        val implementation = RamlConverter(file).conversionResult
+
+        //then
+        assertThat(implementation).containsExactlyInAnyOrderElementsOf(specification)
+    }
+
+    @Test
+    fun `deprecated method`() {
+        //given
+        val file = Paths.get(this::class.java.classLoader.getResource("deprecation/on_method.raml").toURI())
+
+        val specification = setOf(
+                Endpoint(
+                        path = "/todos",
+                        httpMethod = GET,
+                        produces = setOf("text/plain"),
+                        deprecated = true
+                )
+        )
+
+        //when
+        val implementation = RamlConverter(file).conversionResult
+
+        //then
+        assertThat(implementation).containsExactlyInAnyOrderElementsOf(specification)
+    }
+}

--- a/raml/src/test/resources/deprecation/none.raml
+++ b/raml/src/test/resources/deprecation/none.raml
@@ -1,0 +1,14 @@
+#%RAML 1.0
+title: test api
+version: v3
+annotationTypes:
+  deprecated: string
+/todos:
+  displayName: Todos
+  get:
+    displayName: Get all todos
+    responses:
+      200:
+        body:
+          text/plain:
+            type: string

--- a/raml/src/test/resources/deprecation/on_method.raml
+++ b/raml/src/test/resources/deprecation/on_method.raml
@@ -1,0 +1,15 @@
+#%RAML 1.0
+title: test api
+version: v3
+annotationTypes:
+  deprecated: string
+/todos:
+  displayName: Todos
+  get:
+    (deprecated): This method is deprecated
+    displayName: Get all todos
+    responses:
+      200:
+        body:
+          text/plain:
+            type: string

--- a/raml/src/test/resources/deprecation/on_resource.raml
+++ b/raml/src/test/resources/deprecation/on_resource.raml
@@ -1,0 +1,15 @@
+#%RAML 1.0
+title: test api
+version: v3
+annotationTypes:
+  deprecated: string
+/todos:
+  (deprecated): This endpoint is deprecated
+  displayName: Todos
+  get:
+    displayName: Get all todos
+    responses:
+      200:
+        body:
+          text/plain:
+            type: string

--- a/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/SpringConverter.kt
+++ b/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/SpringConverter.kt
@@ -24,7 +24,8 @@ class SpringConverter(private val applicationContext: ApplicationContext) : Abst
             Feature.HeaderParameters,
             Feature.MatrixParameters,
             Feature.Produces,
-            Feature.Consumes
+            Feature.Consumes,
+            Feature.Deprecated
     )
 
     override fun convert(): Set<Endpoint> {
@@ -51,7 +52,9 @@ class SpringConverter(private val applicationContext: ApplicationContext) : Abst
                     headerParameters = mappingEntry.value.hikakuHeaderParameters(),
                     matrixParameters = mappingEntry.value.hikakuMatrixParameters(),
                     produces = mappingEntry.produces(),
-                    consumes = mappingEntry.consumes()
+                    consumes = mappingEntry.consumes(),
+                    deprecated = mappingEntry.value.method.isAnnotationPresent(Deprecated::class.java)
+                            || mappingEntry.value.method.declaringClass.isAnnotationPresent(Deprecated::class.java)
             )
         }
         .toMutableSet()

--- a/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/SpringConverter.kt
+++ b/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/SpringConverter.kt
@@ -25,7 +25,7 @@ class SpringConverter(private val applicationContext: ApplicationContext) : Abst
             Feature.MatrixParameters,
             Feature.Produces,
             Feature.Consumes,
-            Feature.Deprecated
+            Feature.Deprecation
     )
 
     override fun convert(): Set<Endpoint> {

--- a/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/SpringConverter.kt
+++ b/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/SpringConverter.kt
@@ -53,8 +53,7 @@ class SpringConverter(private val applicationContext: ApplicationContext) : Abst
                     matrixParameters = mappingEntry.value.hikakuMatrixParameters(),
                     produces = mappingEntry.produces(),
                     consumes = mappingEntry.consumes(),
-                    deprecated = mappingEntry.value.method.isAnnotationPresent(Deprecated::class.java)
-                            || mappingEntry.value.method.declaringClass.isAnnotationPresent(Deprecated::class.java)
+                    deprecated = mappingEntry.isEndpointDeprecated()
             )
         }
         .toMutableSet()
@@ -65,8 +64,7 @@ class SpringConverter(private val applicationContext: ApplicationContext) : Abst
                     Endpoint(
                             path = cleanedPath,
                             httpMethod = OPTIONS,
-                            deprecated = mappingEntry.value.method.isAnnotationPresent(Deprecated::class.java)
-                                    || mappingEntry.value.method.declaringClass.isAnnotationPresent(Deprecated::class.java)
+                            deprecated = mappingEntry.isEndpointDeprecated()
                     )
             )
         }

--- a/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/SpringConverter.kt
+++ b/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/SpringConverter.kt
@@ -60,11 +60,13 @@ class SpringConverter(private val applicationContext: ApplicationContext) : Abst
         .toMutableSet()
 
         // Spring always adds an OPTIONS http method if it does not exist, but without query and path parameter
-        if(!httpMethods.contains(OPTIONS)) {
+        if (!httpMethods.contains(OPTIONS)) {
             endpoints.add(
                     Endpoint(
                             path = cleanedPath,
-                            httpMethod = OPTIONS
+                            httpMethod = OPTIONS,
+                            deprecated = mappingEntry.value.method.isAnnotationPresent(Deprecated::class.java)
+                                    || mappingEntry.value.method.declaringClass.isAnnotationPresent(Deprecated::class.java)
                     )
             )
         }

--- a/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/extensions/DeprecationExtension.kt
+++ b/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/extensions/DeprecationExtension.kt
@@ -1,0 +1,8 @@
+package de.codecentric.hikaku.converters.spring.extensions
+
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo
+
+internal fun Map.Entry<RequestMappingInfo, HandlerMethod>.isEndpointDeprecated() =
+        this.value.method.isAnnotationPresent(Deprecated::class.java)
+                || this.value.method.declaringClass.isAnnotationPresent(Deprecated::class.java)

--- a/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/deprecation/ConsumesTestController.kt
+++ b/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/deprecation/ConsumesTestController.kt
@@ -1,0 +1,33 @@
+package de.codecentric.hikaku.converters.spring.deprecation
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.*
+
+@SpringBootApplication
+open class DummyApp
+
+data class Todo(val description: String)
+
+@Controller
+open class NoDeprecationController {
+
+    @RequestMapping("/todos")
+    fun todos(@RequestBody todo: Todo) { }
+}
+
+@Controller
+@Deprecated("Test")
+open class DeprecatedClassController {
+
+    @RequestMapping("/todos")
+    fun todos(@RequestBody todo: Todo) { }
+}
+
+@Controller
+open class DeprecatedFunctionController {
+
+    @RequestMapping("/todos")
+    @Deprecated("Test")
+    fun todos(@RequestBody todo: Todo) { }
+}

--- a/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/deprecation/DeprecationTestController.kt
+++ b/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/deprecation/DeprecationTestController.kt
@@ -12,7 +12,7 @@ data class Todo(val description: String)
 @Controller
 open class NoDeprecationController {
 
-    @RequestMapping("/todos")
+    @GetMapping("/todos")
     fun todos(@RequestBody todo: Todo) { }
 }
 
@@ -20,14 +20,14 @@ open class NoDeprecationController {
 @Deprecated("Test")
 open class DeprecatedClassController {
 
-    @RequestMapping("/todos")
+    @GetMapping("/todos")
     fun todos(@RequestBody todo: Todo) { }
 }
 
 @Controller
 open class DeprecatedFunctionController {
 
-    @RequestMapping("/todos")
+    @GetMapping("/todos")
     @Deprecated("Test")
     fun todos(@RequestBody todo: Todo) { }
 }

--- a/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/deprecation/SpringConverterDeprecationTest.kt
+++ b/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/deprecation/SpringConverterDeprecationTest.kt
@@ -1,0 +1,190 @@
+package de.codecentric.hikaku.converters.spring.deprecation
+
+import de.codecentric.hikaku.converters.spring.SpringConverter
+import de.codecentric.hikaku.endpoints.Endpoint
+import de.codecentric.hikaku.endpoints.HttpMethod.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.http.MediaType
+
+class SpringConverterDeprecationTest {
+
+    @Nested
+    @WebMvcTest(NoDeprecationController::class, excludeAutoConfiguration = [ErrorMvcAutoConfiguration::class])
+    inner class NoDeprecationTest {
+
+        @Autowired
+        lateinit var context: ConfigurableApplicationContext
+
+        @Test
+        fun `no deprecation`() {
+            //given
+            val specification: Set<Endpoint> = setOf(
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = GET,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = false
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = POST,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = false
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = HEAD,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = false
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = PUT,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = false
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = PATCH,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = false
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = DELETE,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = false
+                    ),
+                    Endpoint("/todos", OPTIONS, deprecated = false)
+            )
+
+            //when
+            val implementation = SpringConverter(context)
+
+            //then
+            assertThat(implementation.conversionResult).containsExactlyInAnyOrderElementsOf(specification)
+        }
+    }
+
+    @Nested
+    @WebMvcTest(DeprecatedClassController::class, excludeAutoConfiguration = [ErrorMvcAutoConfiguration::class])
+    inner class NoDeprecatedClassTest {
+
+        @Autowired
+        lateinit var context: ConfigurableApplicationContext
+
+        @Test
+        fun `deprecated class`() {
+            //given
+            val specification: Set<Endpoint> = setOf(
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = GET,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = POST,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = HEAD,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = PUT,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = PATCH,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = DELETE,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint("/todos", OPTIONS, deprecated = true)
+            )
+
+            //when
+            val implementation = SpringConverter(context)
+
+            //then
+            assertThat(implementation.conversionResult).containsExactlyInAnyOrderElementsOf(specification)
+        }
+    }
+
+    @Nested
+    @WebMvcTest(DeprecatedFunctionController::class, excludeAutoConfiguration = [ErrorMvcAutoConfiguration::class])
+    inner class NoDeprecatedFunctionTest {
+
+        @Autowired
+        lateinit var context: ConfigurableApplicationContext
+
+        @Test
+        fun `deprcated function`() {
+            //given
+            val specification: Set<Endpoint> = setOf(
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = GET,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = POST,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = HEAD,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = PUT,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = PATCH,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint(
+                            path = "/todos",
+                            httpMethod = DELETE,
+                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
+                            deprecated = true
+                    ),
+                    Endpoint("/todos", OPTIONS, deprecated = true)
+            )
+
+            //when
+            val implementation = SpringConverter(context)
+
+            //then
+            assertThat(implementation.conversionResult).containsExactlyInAnyOrderElementsOf(specification)
+        }
+    }
+}

--- a/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/deprecation/SpringConverterDeprecationTest.kt
+++ b/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/deprecation/SpringConverterDeprecationTest.kt
@@ -33,31 +33,7 @@ class SpringConverterDeprecationTest {
                     ),
                     Endpoint(
                             path = "/todos",
-                            httpMethod = POST,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = false
-                    ),
-                    Endpoint(
-                            path = "/todos",
                             httpMethod = HEAD,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = false
-                    ),
-                    Endpoint(
-                            path = "/todos",
-                            httpMethod = PUT,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = false
-                    ),
-                    Endpoint(
-                            path = "/todos",
-                            httpMethod = PATCH,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = false
-                    ),
-                    Endpoint(
-                            path = "/todos",
-                            httpMethod = DELETE,
                             consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
                             deprecated = false
                     ),
@@ -91,31 +67,7 @@ class SpringConverterDeprecationTest {
                     ),
                     Endpoint(
                             path = "/todos",
-                            httpMethod = POST,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = true
-                    ),
-                    Endpoint(
-                            path = "/todos",
                             httpMethod = HEAD,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = true
-                    ),
-                    Endpoint(
-                            path = "/todos",
-                            httpMethod = PUT,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = true
-                    ),
-                    Endpoint(
-                            path = "/todos",
-                            httpMethod = PATCH,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = true
-                    ),
-                    Endpoint(
-                            path = "/todos",
-                            httpMethod = DELETE,
                             consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
                             deprecated = true
                     ),
@@ -149,31 +101,7 @@ class SpringConverterDeprecationTest {
                     ),
                     Endpoint(
                             path = "/todos",
-                            httpMethod = POST,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = true
-                    ),
-                    Endpoint(
-                            path = "/todos",
                             httpMethod = HEAD,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = true
-                    ),
-                    Endpoint(
-                            path = "/todos",
-                            httpMethod = PUT,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = true
-                    ),
-                    Endpoint(
-                            path = "/todos",
-                            httpMethod = PATCH,
-                            consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
-                            deprecated = true
-                    ),
-                    Endpoint(
-                            path = "/todos",
-                            httpMethod = DELETE,
                             consumes = setOf(MediaType.APPLICATION_JSON_UTF8_VALUE),
                             deprecated = true
                     ),


### PR DESCRIPTION
This pull request adds support for ensuring deprecation in specs match with classes/methods marked as deprecated.

✔️ **Included in PR**
- matrix in [`features.md` was updated](https://github.com/codecentric/hikaku/pull/40/files?short_path=e71cfa1#diff-e71cfa1c040ef2eea5de14baab837af9)
- every change is covered by tests
  - except `CommandLineReporter` since there are no tests for it
- JAX-RS: checks for `@Deprecated` on method or class
- Micronaut: checks for `@Deprecated` on method or class
- OpenApi: checks for `deprecated: true|false` on operation
- RAML: checks for `deprecated` annotation on resource(endpoint) or http method
- Spring: checks for `@Deprecated` on method or class

⚠️ **Notes**
- WADL is not supported (AFAIK it does not support deprecating)
- didn't know which version to use in `features.md`