### PR TITLE
HikakuConfig: add possibility to filter the endpoints with a custom predicate

### DIFF
--- a/core/src/main/kotlin/de/codecentric/hikaku/Hikaku.kt
+++ b/core/src/main/kotlin/de/codecentric/hikaku/Hikaku.kt
@@ -26,6 +26,7 @@ class Hikaku(
         return this.filterNot { config.ignorePaths.contains(it.path) }
                 .filterNot { config.ignoreHttpMethodHead && it.httpMethod == HEAD }
                 .filterNot { config.ignoreHttpMethodOptions && it.httpMethod == OPTIONS }
+                .filter(config.endpointFilter)
     }
 
     private fun reportResult(matchResult: MatchResult) {

--- a/core/src/main/kotlin/de/codecentric/hikaku/HikakuConfig.kt
+++ b/core/src/main/kotlin/de/codecentric/hikaku/HikakuConfig.kt
@@ -13,11 +13,13 @@ import de.codecentric.hikaku.reporters.Reporter
  * @param ignoreHttpMethodHead All checks for an [Endpoint] providing http method [HEAD] will be skipped if set to `true`.
  * @param ignoreHttpMethodOptions All checks for an [Endpoint] providing http method [OPTIONS] will be skipped if set to `true`.
  * @param reporter The [MatchResult] will be passed to one or many [Reporter] before the test either fails or succeeds. Default is a [CommandLineReporter] that prints the results to [System.out].
+ * @param endpointFilter Filtering rule: only the [Endpoint]s matching the predicate will be considered.
  */
 data class HikakuConfig
 @JvmOverloads constructor(
         val ignorePaths: Set<String> = emptySet(),
         val ignoreHttpMethodHead: Boolean = false,
         val ignoreHttpMethodOptions: Boolean = false,
-        val reporter: List<Reporter> = listOf(CommandLineReporter())
+        val reporter: List<Reporter> = listOf(CommandLineReporter()),
+        val endpointFilter: (Endpoint) -> Boolean = { _ -> true }
 )


### PR DESCRIPTION
Hi, for a project I needed a little bit more flexibility for ignoring the endpoints paths.

The provided `ignorePaths` in `HikakuConfig` is restrictive as you need an exact match.

I've added a new `endpointFilter` predicate that the user can customize as he wants :)

I hope that you will find it useful :)

Thanks!