### PR TITLE
Spring: support all media-types for consumes

### DIFF
--- a/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/consumes/ConsumesTestController.kt
+++ b/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/consumes/ConsumesTestController.kt
@@ -4,6 +4,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.http.MediaType.*
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 
 @SpringBootApplication
 open class DummyApp
@@ -41,6 +42,21 @@ open class RequestMappingOneMediaTypeIsExtractedCorrectlyController {
 
     @RequestMapping("/todos", consumes = [APPLICATION_XML_VALUE])
     fun todos(@RequestBody todo: Todo) { }
+}
+
+@Controller
+@Suppress("UNUSED_PARAMETER")
+open class RequestMappingMultipartFormIsExtractedCorrectlyController {
+
+    @RequestMapping(
+            path = ["/form"],
+            method = [RequestMethod.POST],
+            consumes = [MULTIPART_FORM_DATA_VALUE]
+    )
+    fun form(
+            @RequestPart("title") title: String,
+            @RequestPart("file") form: MultipartFile
+    ) { }
 }
 
 @Controller
@@ -120,7 +136,7 @@ open class RequestMappingOnClassWithoutRequestBodyAnnotationController {
 
 @Controller
 @Suppress("UNUSED_PARAMETER")
-open class RequestMappingOnFunctionWithoutRequestBodyAnnotationController {
+open class RequestMappingOnFunctionWithoutConsumesAnnotationController {
 
     @RequestMapping("/todos")
     fun todos(todo: String) { }

--- a/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/consumes/SpringConverterConsumesTest.kt
+++ b/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/consumes/SpringConverterConsumesTest.kt
@@ -19,14 +19,14 @@ class SpringConverterConsumesTest {
 
         @Nested
         inner class ClassLevelTests {
-            
+
             @Nested
             @WebMvcTest(RequestMappingOneMediaTypeIsInheritedByAllFunctionsController::class, excludeAutoConfiguration = [ErrorMvcAutoConfiguration::class])
             inner class OneMediaTypeIsInheritedByAllFunctionsTest {
-    
+
                 @Autowired
                 lateinit var context: ConfigurableApplicationContext
-    
+
                 @Test
                 fun `media type declared at class level using RequestMapping annotation is inherited by all functions`() {
                     //given
@@ -94,22 +94,22 @@ class SpringConverterConsumesTest {
                             ),
                             Endpoint("/tags", OPTIONS)
                     )
-    
+
                     //when
                     val implementation = SpringConverter(context)
-    
+
                     //then
                     assertThat(implementation.conversionResult).containsExactlyInAnyOrderElementsOf(specification)
                 }
             }
-    
+
             @Nested
             @WebMvcTest(RequestMappingMultipleMediaTypesAreInheritedByAllFunctionsController::class, excludeAutoConfiguration = [ErrorMvcAutoConfiguration::class])
             inner class MultipleMediaTypesAreInheritedByAllFunctionsTest {
-    
+
                 @Autowired
                 lateinit var context: ConfigurableApplicationContext
-    
+
                 @Test
                 fun `multiple media types declared at class level using RequestMapping annotation are inherited by all functions`() {
                     //given
@@ -177,10 +177,10 @@ class SpringConverterConsumesTest {
                             ),
                             Endpoint("/tags", OPTIONS)
                     )
-    
+
                     //when
                     val implementation = SpringConverter(context)
-    
+
                     //then
                     assertThat(implementation.conversionResult).containsExactlyInAnyOrderElementsOf(specification)
                 }
@@ -318,17 +318,17 @@ class SpringConverterConsumesTest {
                 }
             }
         }
-        
+
         @Nested
         inner class FunctionLevelTests {
-            
+
             @Nested
             @WebMvcTest(RequestMappingOneMediaTypeIsExtractedCorrectlyController::class, excludeAutoConfiguration = [ErrorMvcAutoConfiguration::class])
             inner class OneMediaTypeIsExtractedCorrectlyTest {
-    
+
                 @Autowired
                 lateinit var context: ConfigurableApplicationContext
-    
+
                 @Test
                 fun `media type declared at function level using RequestMapping annotation is extracted correctly`() {
                     //given
@@ -365,22 +365,57 @@ class SpringConverterConsumesTest {
                             ),
                             Endpoint("/todos", OPTIONS)
                     )
-    
+
                     //when
                     val implementation = SpringConverter(context)
-    
+
                     //then
                     assertThat(implementation.conversionResult).containsExactlyInAnyOrderElementsOf(specification)
                 }
             }
-    
+
+            @Nested
+            @WebMvcTest(RequestMappingMultipartFormIsExtractedCorrectlyController::class, excludeAutoConfiguration = [ErrorMvcAutoConfiguration::class])
+            inner class MultipartFormIsExtractedCorrectlyTest {
+
+                @Autowired
+                lateinit var context: ConfigurableApplicationContext
+
+                @Test
+                fun `multipart form media type is extracted correctly`() {
+                    //given
+                    val specification: Set<Endpoint> = setOf(
+                            Endpoint(
+                                    path = "/form",
+                                    httpMethod = POST,
+                                    consumes = setOf(MULTIPART_FORM_DATA_VALUE)
+                            ),
+                            Endpoint(
+                                    path = "/form",
+                                    httpMethod = HEAD,
+                                    consumes = setOf(MULTIPART_FORM_DATA_VALUE)
+                            ),
+                            Endpoint(
+                                    path = "/form",
+                                    httpMethod = OPTIONS,
+                            ),
+                    )
+
+                    //when
+                    val implementation = SpringConverter(context)
+
+                    //then
+                    assertThat(implementation.conversionResult).containsExactlyInAnyOrderElementsOf(specification)
+                }
+            }
+
             @Nested
             @WebMvcTest(RequestMappingMultipleMediaTypesAreExtractedCorrectlyController::class, excludeAutoConfiguration = [ErrorMvcAutoConfiguration::class])
             inner class MultipleMediaTypesAreExtractedCorrectlyTest {
-    
+
                 @Autowired
                 lateinit var context: ConfigurableApplicationContext
-    
+
                 @Test
                 fun `multiple media types declared at function level using RequestMapping annotation are extracted correctly`() {
                     //given
@@ -417,10 +452,10 @@ class SpringConverterConsumesTest {
                             ),
                             Endpoint("/todos", OPTIONS)
                     )
-    
+
                     //when
                     val implementation = SpringConverter(context)
-    
+
                     //then
                     assertThat(implementation.conversionResult).containsExactlyInAnyOrderElementsOf(specification)
                 }
@@ -531,14 +566,14 @@ class SpringConverterConsumesTest {
             }
 
             @Nested
-            @WebMvcTest(RequestMappingOnFunctionWithoutRequestBodyAnnotationController::class, excludeAutoConfiguration = [ErrorMvcAutoConfiguration::class])
-            inner class NoRequestBodyAnnotationTest {
+            @WebMvcTest(RequestMappingOnFunctionWithoutConsumesAnnotationController::class, excludeAutoConfiguration = [ErrorMvcAutoConfiguration::class])
+            inner class EmptyAnnotationTest {
 
                 @Autowired
                 lateinit var context: ConfigurableApplicationContext
 
                 @Test
-                fun `no RequestBody annotation results in an empty produces list`() {
+                fun `no RequestBody nor consumes annotation results in an empty produces list`() {
                     //given
                     val specification: Set<Endpoint> = setOf(
                             Endpoint("/todos", GET),


### PR DESCRIPTION
# Problem
In Spring, we require the usage of `@RequestBody` annotation before we actually check for `consumes` in `@RequestMapping` (or any variation of that). This is quite limiting because `@RequestBody` only supports `application/json` and `application/xml` media-type.
For example, it is currently impossible to use `mutlipart/form-data` media type.

# Solution
Only check for `@RequestBody` in case there is no `consumes` annotation already provided in `RequestMapping`.

# Potential improvements
We could make it a little more smart and set it to `multipart/form-data` in case we use `@RequestPart` or one of the parameter if of type `MultipartFile`. I honestly think this is more of an edge case and probably it's not worth it to add this extra complexity, but let me know what you think :)