### PR TITLE
Fix exception: patternsCondition is Nullable

### DIFF
--- a/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/extensions/PathsSpringExtension.kt
+++ b/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/extensions/PathsSpringExtension.kt
@@ -3,5 +3,8 @@ package de.codecentric.hikaku.converters.spring.extensions
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo
 
 internal fun RequestMappingInfo.paths(): Set<String> {
+    if (this.patternsCondition == null) {
+        return emptySet()
+    }
     return this.patternsCondition?.patterns ?: emptySet()
 }


### PR DESCRIPTION
See the @Nullable annotation here: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/mvc/method/RequestMappingInfo.html#getPatternsCondition--

See also RequestMappingInfo.java line 91 in org.springframework:spring-webmvc:5.3.14

The current code can result in this stack trace:

java.lang.IllegalStateException: this.patternsCondition must not be null
	at de.codecentric.hikaku.converters.spring.extensions.PathsSpringExtensionKt.paths(PathsSpringExtension.kt:6)
	at de.codecentric.hikaku.converters.spring.SpringConverter.convert(SpringConverter.kt:35)
	at de.codecentric.hikaku.converters.AbstractEndpointConverter$conversionResult$2.invoke(AbstractEndpointConverter.kt:11)
	at de.codecentric.hikaku.converters.AbstractEndpointConverter$conversionResult$2.invoke(AbstractEndpointConverter.kt:8)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at de.codecentric.hikaku.converters.AbstractEndpointConverter.getConversionResult(AbstractEndpointConverter.kt)
	at de.codecentric.hikaku.Hikaku.match(Hikaku.kt:46)