### PR TITLE
Support google-style api custom methods

### DIFF
--- a/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/SpringConverter.kt
+++ b/spring/src/main/kotlin/de/codecentric/hikaku/converters/spring/SpringConverter.kt
@@ -73,10 +73,11 @@ class SpringConverter(private val applicationContext: ApplicationContext) : Abst
     }
 
     private fun removeRegex(path: String): String {
+        val segmentRegex = """\{([a-zA-Z][a-zA-Z0-9]+)(:.*)}""".toRegex()
         return path.split('/').joinToString("/") { pathSegment ->
             pathSegment.let {
                 when {
-                    it.contains(':') -> it.replace(Regex(":.*"), "}")
+                    it.contains(':') -> it.replace(segmentRegex, "{$1}")
                     else -> it
                 }
             }

--- a/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/path/PathTestController.kt
+++ b/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/path/PathTestController.kt
@@ -82,6 +82,14 @@ open class RequestMappingOnFunctionProvidingMultipleRegexForPathVariableControll
 }
 
 @Controller
+@Suppress("UNUSED_PARAMETER")
+open class RequestMappingOnFunctionProvidingCustomMethodStylePathController {
+
+    @RequestMapping("/todos/list:clear", method = [GET])
+    fun todo() { }
+}
+
+@Controller
 open class GetMappingOnFunctionWithMultiplePathsController {
 
     @GetMapping("/todos", "/todo/list")

--- a/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/path/SpringConverterPathTest.kt
+++ b/spring/src/test/kotlin/de/codecentric/hikaku/converters/spring/path/SpringConverterPathTest.kt
@@ -323,6 +323,35 @@ class SpringConverterPathTest {
                     assertThat(implementation.conversionResult).containsExactlyInAnyOrderElementsOf(specification)
                 }
             }
+
+            @Nested
+            @WebMvcTest(RequestMappingOnFunctionProvidingCustomMethodStylePathController::class, excludeAutoConfiguration = [ErrorMvcAutoConfiguration::class])
+            inner class RequestMappingOnFunctionProvidingCustomMethodStylePathTest {
+                @Autowired
+                lateinit var context: ConfigurableApplicationContext
+
+                @Test
+                fun `endpoint having regex on path parameter and using google-style using RequestMapping converts to a path without the regex`() {
+                    //given
+                    val specification: Set<Endpoint> = setOf(
+                        Endpoint(
+                            path = "/todos/list:clear",
+                            httpMethod = GET,
+                        ),
+                        Endpoint(
+                            path = "/todos/list:clear",
+                            httpMethod = HEAD,
+                        ),
+                        Endpoint("/todos/list:clear", OPTIONS)
+                    )
+
+                    //when
+                    val implementation = SpringConverter(context)
+
+                    //then
+                    assertThat(implementation.conversionResult).containsExactlyInAnyOrderElementsOf(specification)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Support google-style api custom methods, for example:  `https://service.name/v1/some/resource/name:customVerb
`.
More details about the api guidelines can be found [here](https://cloud.google.com/apis/design/custom_methods).

This pull request just extends SpringConverter's `removeRegex` private method to only replace the specific regex part of a path segment. 